### PR TITLE
Merge master back to develop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
+
 go:
     - 1.8
     - tip

--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ If you have any issues, please open one here on Github or hit me up on twitter [
 
 ## CHANGELOG
 
+## 1.6.0
+
+* Added transitions to the config and outputting the transitions to STDout to
+  verify the config.
 
 ## 1.4.0
 

--- a/cmd/gong/.bumpversion.cfg
+++ b/cmd/gong/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.4.0
+current_version = 1.6.0
 commit = False
 tag = False
 

--- a/cmd/gong/build.sh
+++ b/cmd/gong/build.sh
@@ -1,2 +1,2 @@
-bumpversion $1
+bumpversion $1 --allow-dirty
 go build

--- a/cmd/gong/main.go
+++ b/cmd/gong/main.go
@@ -13,7 +13,7 @@ import (
 
 func main() {
 	app := cli.NewApp()
-	app.Version = "1.4.0"
+	app.Version = "1.6.0"
 
 	var branchType string
 

--- a/jira.go
+++ b/jira.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/andygrunwald/go-jira"
 )
@@ -127,11 +128,12 @@ func indexOf(status string, data []string) int {
 
 // Start : Start an issue
 func (j *JiraClient) Start(issueType string, issueID string) (string, error) {
-	allowed := []string{"Ready", "Start"}
+	allowed := strings.Split(j.config["transitions"], ",")
 
 	fmt.Println(issueID)
 
 	transitions, response, err := j.client.Issue.GetTransitions(issueID)
+	fmt.Println(transitions)
 
 	if err != nil {
 		fmt.Println(err)
@@ -176,6 +178,7 @@ func (j *JiraClient) GetAuthFields() map[string]bool {
 		"domain":         true,
 		"password":       true,
 		"project_prefix": false,
+		"transitions":    false,
 	}
 }
 


### PR DESCRIPTION
Not sure why the `transitions` feature have been added directly to master so merging back to develop.
I guess this project use the traditional doing PRs on develop and building the release on master?
Wanted to start implementing new features starting from a clean project state, please do tell if this PR is not what is expected, thanks! 😃