### PR TITLE
Add more info regarding Jira login

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ In order to use `gong` you first you need to login.
 
 `gong login {client-name}`
 
-Each of the supported clients will prompt the required fields in order to login to the system. Jira will need username, pass and a couple more while others might only need an API token.
+Each of the supported clients will prompt the required fields in order to login to the system. Jira will need username, password, domain (without the https://) scheme while others might only need an API token.
 
 Once you input all of the details the client will attempt to login. If succeeded it will let you know.
 

--- a/client.go
+++ b/client.go
@@ -120,7 +120,7 @@ func Login(client Client) (bool, error) {
 		return true, nil
 	}
 
-	return false, fmt.Errorf("Cloud not login")
+	return false, fmt.Errorf("Could not login")
 }
 
 func getUserHomeOrDefault() string {

--- a/jira.go
+++ b/jira.go
@@ -174,8 +174,8 @@ func (j *JiraClient) FormatField(fieldName string, value string) string {
 // GetAuthFields : Get a map of auth fields
 func (j *JiraClient) GetAuthFields() map[string]bool {
 	return map[string]bool{
-		"username":       true,
-		"domain":         true,
+		"username":       false,
+		"domain":         false,
 		"password":       true,
 		"project_prefix": false,
 		"transitions":    false,

--- a/jira.go
+++ b/jira.go
@@ -174,8 +174,8 @@ func (j *JiraClient) FormatField(fieldName string, value string) string {
 // GetAuthFields : Get a map of auth fields
 func (j *JiraClient) GetAuthFields() map[string]bool {
 	return map[string]bool{
-		"username":       false,
 		"domain":         false,
+		"username":       false,
 		"password":       true,
 		"project_prefix": false,
 		"transitions":    false,


### PR DESCRIPTION
I struggled during the Jira login phase and had to dig in the code to understand that the domain should be added without the `https://` scheme.

- Added domain format specifics to `README.md`
- Fix `cloud` type in error message
- `username` and `domain` are not hidden behind stars while typed
- Ask about Jira domain before username and password (order seems, at least to me, more logical)