### PR TITLE
Allow different branch name format

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,20 @@ Once you input all of the details the client will attempt to login. If succeeded
 
 [![asciicast](https://asciinema.org/a/dcko3kv5xwobpf4rgj0e4ulyo.png)](https://asciinema.org/a/dcko3kv5xwobpf4rgj0e4ulyo)
 
+### Configuration
+
+It is possible to add the following options to your `~/.gong.json`:
+```json
+"branch_replacement_character": "_"
+```
+Replace any illegal characters in a branch name with the provided character.  
+By default `-` is used
+```json
+"branch_pattern": "{{.IssueID}}/{{.IssueTitle}}"
+```
+Use this pattern to create the branch name from the issue, accept `{{.IssueID}}`, `{{.IssueTitle}}` and `{{.IssueType}}`. `{{.IssueID}}` and `{{.IssueTitle}}` are mandatory.  
+By default `{{.IssueType}}/{{.IssueID}}-{{.IssueTitle}}` is used
+
 ### Start working on an issue
 
 `gong start {issue-id} --type feature`
@@ -54,7 +68,7 @@ issue id and what type of work is this (defaults to feature).
 
 This will do a couple of things
 
-1. Create a branch name `{type}/{issue-id}-{issue-title-sluggified}`
+1. Create a branch name, by default: `{type}/{issue-id}-{issue-title-sluggified}`
 2. Transition the issue to a started state
 
 [![asciicast](https://asciinema.org/a/c5libsysjmb5f8f8gizkbldzv.png)](https://asciinema.org/a/c5libsysjmb5f8f8gizkbldzv)

--- a/branch.go
+++ b/branch.go
@@ -1,0 +1,64 @@
+package gong
+
+import (
+	"fmt"
+	"bytes"
+	"text/template"
+	"strings"
+)
+
+type Branch struct {
+	pattern              string
+	replacementCharacter string
+}
+
+type BranchName struct {
+	IssueType  string
+	IssueID    string
+	IssueTitle string
+}
+
+var issueTypeTemplate = "{{.IssueType}}"
+var issueIDTemplate = "{{.IssueID}}"
+var issueTitleTemplate = "{{.IssueTitle}}"
+var defaultPattern = fmt.Sprintf(`%s/%s-%s`, issueTypeTemplate, issueIDTemplate, issueTitleTemplate)
+
+func NewBranch(configuration map[string]string) (Branch, error) {
+	pattern := fieldOrDefault(configuration, "branch_pattern", defaultPattern)
+	if err := validatePattern(pattern); err != nil {
+		return Branch{}, err
+	}
+	replacementCharacter := fieldOrDefault(configuration, "branch_replacement_character", "-")
+	return Branch{pattern, replacementCharacter}, nil
+}
+
+func fieldOrDefault(configuration map[string]string, field string, defaultValue string) string {
+	value := configuration[field]
+	if value == "" {
+		return defaultValue
+	}
+	return value
+}
+
+func validatePattern(pattern string) error {
+	if strings.Contains(pattern, issueIDTemplate) && strings.Contains(pattern, issueTitleTemplate) {
+		return nil
+	}
+	return fmt.Errorf("branch_pattern should have both %s and %s", issueIDTemplate, issueTitleTemplate)
+}
+
+func (b *Branch) Name(issueType string, issueID string, issueTitle string) (string, error) {
+	branchTemplate := template.New("template")
+	branchTemplate, err := branchTemplate.Parse(b.pattern)
+	if err != nil {
+		return "", err
+	}
+	formattedTitle := SlugifyTitle(issueTitle, b.replacementCharacter)
+	branchName := BranchName{issueType, issueID, formattedTitle}
+	var result bytes.Buffer
+	if err := branchTemplate.Execute(&result, branchName); err != nil {
+		return "", err
+	}	
+	fmt.Printf(result.String())
+	return result.String(), nil
+}

--- a/branch_test.go
+++ b/branch_test.go
@@ -1,0 +1,70 @@
+package gong
+
+import (
+	. "gopkg.in/check.v1"
+	"testing"
+)
+
+func TestBranch(t *testing.T) { TestingT(t) }
+
+type BranchSuite struct{}
+
+var _ = Suite(&BranchSuite{})
+
+const issueType = "type"
+const issueID = "id"
+const issueTitle = "title somewhat long"
+
+func (b *BranchSuite) TestDefaultPatternAndDefaultReplacementCharacterWhenConfigFieldsMissing(c *C) {
+	config := map[string]string{}
+	branch, err := NewBranch(config)
+
+	branchName, err := branch.Name(issueType, issueID, issueTitle)
+
+	c.Assert(err, Equals, nil)
+	c.Assert(branchName, Equals, "type/id-title-somewhat-long")
+}
+
+func (b *BranchSuite) TestUseReplacementCharacterWhenConfigFieldPresent(c *C) {
+	config := map[string]string {
+		"branch_replacement_character": "_",
+	}
+	branch, err := NewBranch(config)
+
+	branchName, err := branch.Name(issueType, issueID, issueTitle)
+
+	c.Assert(err, Equals, nil)
+	c.Assert(branchName, Equals, "type/id-title_somewhat_long")
+}
+
+func (b *BranchSuite) TestUsePatternWhenConfigFieldPresent(c *C) {
+	config := map[string]string {
+		"branch_pattern": "{{.IssueTitle}}+{{.IssueID}}-{{.IssueType}}",
+	}
+	branch, err := NewBranch(config)
+
+	branchName, err := branch.Name(issueType, issueID, issueTitle)
+
+	c.Assert(err, Equals, nil)
+	c.Assert(branchName, Equals, "title-somewhat-long+id-type")
+}
+
+func (b *BranchSuite) TestFailWhenIssueTitleNotPresentInPattern(c *C) {
+	config := map[string]string {
+		"branch_pattern": "{{.IssueType}}/{{.IssueID}}",
+	}
+
+	_, err := NewBranch(config)
+
+	c.Assert(err, NotNil)
+}
+
+func (b *BranchSuite) TestFailWhenIssueIDNotPresentInPattern(c *C) {
+	config := map[string]string {
+		"branch_pattern": "{{.IssueTitle}}+{{.IssueType}}",
+	}
+
+	_, err := NewBranch(config)
+
+	c.Assert(err, 	NotNil)
+}

--- a/client.go
+++ b/client.go
@@ -1,12 +1,8 @@
 package gong
 
 import (
-	"encoding/json"
 	"fmt"
 	"github.com/segmentio/go-prompt"
-	"io/ioutil"
-	"os/user"
-	"path/filepath"
 )
 
 // Client : Public interface for the generic client
@@ -121,57 +117,4 @@ func Login(client Client) (bool, error) {
 	}
 
 	return false, fmt.Errorf("Cloud not login")
-}
-
-func getUserHomeOrDefault() string {
-	usr, err := user.Current()
-
-	if err != nil {
-		return "./"
-	}
-
-	return usr.HomeDir
-}
-
-func getFileLocation() string {
-	dir := getUserHomeOrDefault()
-	return filepath.Join(dir, ".gong.json")
-}
-
-// Load : Load the configuration from a file
-func Load() (map[string]string, error) {
-	fileLocation := getFileLocation()
-	var c = map[string]string{}
-
-	file, err := ioutil.ReadFile(fileLocation)
-
-	if err != nil {
-		return nil, err
-	}
-
-	err = json.Unmarshal(file, &c)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return c, nil
-}
-
-// Save : saves the configuration to a file
-func Save(values map[string]string) error {
-	fileLocation := getFileLocation()
-	loginDetails, err := json.Marshal(values)
-
-	if err != nil {
-		return err
-	}
-
-	err = ioutil.WriteFile(fileLocation, loginDetails, 0644)
-
-	if err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/cmd/gong/main.go
+++ b/cmd/gong/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/KensoDev/gong"
+	"gong"
 	"github.com/fatih/color"
 	"github.com/urfave/cli"
 )
@@ -74,6 +74,7 @@ func main() {
 				branchName, err := gong.Start(client, branchType, issueId)
 				if err != nil {
 					color.Red("Problem with starting the issue")
+					fmt.Println(err)
 				}
 
 				cmd := "git"

--- a/cmd/gong/main.go
+++ b/cmd/gong/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"os/exec"
 
-	"gong"
+	"github.com/KensoDev/gong"
 	"github.com/fatih/color"
 	"github.com/urfave/cli"
 )
@@ -74,7 +74,6 @@ func main() {
 				branchName, err := gong.Start(client, branchType, issueId)
 				if err != nil {
 					color.Red("Problem with starting the issue")
-					fmt.Println(err)
 				}
 
 				cmd := "git"

--- a/configuration.go
+++ b/configuration.go
@@ -1,0 +1,61 @@
+package gong
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os/user"
+	"path/filepath"
+)
+
+// Load : Load the configuration from a file
+func Load() (map[string]string, error) {
+	fileLocation := getFileLocation()
+	var c = map[string]string{}
+
+	file, err := ioutil.ReadFile(fileLocation)
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(file, &c)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+func getUserHomeOrDefault() string {
+	usr, err := user.Current()
+
+	if err != nil {
+		return "./"
+	}
+
+	return usr.HomeDir
+}
+
+func getFileLocation() string {
+	dir := getUserHomeOrDefault()
+	return filepath.Join(dir, ".gong.json")
+}
+
+// Save : saves the configuration to a file
+func Save(values map[string]string) error {
+	fileLocation := getFileLocation()
+	loginDetails, err := json.Marshal(values)
+
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(fileLocation, loginDetails, 0644)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/jira.go
+++ b/jira.go
@@ -13,6 +13,7 @@ import (
 type JiraClient struct {
 	client *jira.Client
 	config map[string]string
+	branch Branch
 }
 
 func (j *JiraClient) Create() (string, error) {
@@ -113,8 +114,7 @@ func (j *JiraClient) GetBranchName(issueType string, issueID string) (string, er
 		return "", err
 	}
 
-	issueTitleSlug := SlugifyTitle(issue.Fields.Summary)
-	return fmt.Sprintf("%s/%s-%s", issueType, issueID, issueTitleSlug), nil
+	return j.branch.Name(issueType, issueID, issue.Fields.Summary)
 }
 
 func indexOf(status string, data []string) int {
@@ -198,6 +198,12 @@ func (j *JiraClient) Authenticate(fields map[string]string) bool {
 
 	j.client = jiraClient
 	j.config = fields
+	j.branch, err = NewBranch(fields)
+
+	if err != nil {
+        fmt.Println(err)
+		return false
+	}
 
 	return true
 }

--- a/jira.go
+++ b/jira.go
@@ -201,7 +201,7 @@ func (j *JiraClient) Authenticate(fields map[string]string) bool {
 	j.branch, err = NewBranch(fields)
 
 	if err != nil {
-        fmt.Println(err)
+		fmt.Println(err)
 		return false
 	}
 

--- a/pivotal.go
+++ b/pivotal.go
@@ -180,7 +180,7 @@ func (p *PivotalClient) Authenticate(fields map[string]string) bool {
 	p.branch, err = NewBranch(fields)
 
 	if err != nil {
-        fmt.Println(err)
+		fmt.Println(err)
 		return false
 	}
 

--- a/pivotal.go
+++ b/pivotal.go
@@ -2,15 +2,17 @@ package gong
 
 import (
 	"fmt"
-	"gopkg.in/salsita/go-pivotaltracker.v1/v5/pivotal"
-	"strconv"
 	"regexp"
+	"strconv"
+
+	"gopkg.in/salsita/go-pivotaltracker.v1/v5/pivotal"
 )
 
 // PivotalClient : Struct implementing the generic Client interface
 type PivotalClient struct {
 	client *pivotal.Client
 	config map[string]string
+	branch Branch
 }
 
 // NewPivotalClient : Returns a pointer to PivotalClient
@@ -20,7 +22,7 @@ func NewPivotalClient() *PivotalClient {
 
 func (p *PivotalClient) Create() (string, error) {
 	fields, err := Load()
-	
+
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -134,9 +136,7 @@ func (p *PivotalClient) GetBranchName(issueType string, issueID string) (string,
 		fmt.Println(err)
 	}
 
-	issueTitleSlug := SlugifyTitle(story.Name)
-
-	return fmt.Sprintf("%s/%s-%s", issueType, issueID, issueTitleSlug), nil
+	return p.branch.Name(issueType, issueID, story.Name)
 }
 
 func (p *PivotalClient) GetProjectIdAndIssueId(issueID string) (int, int, error) {
@@ -177,6 +177,12 @@ func (p *PivotalClient) Authenticate(fields map[string]string) bool {
 
 	p.client = pivotalClient
 	p.config = fields
+	p.branch, err = NewBranch(fields)
+
+	if err != nil {
+        fmt.Println(err)
+		return false
+	}
 
 	return true
 }

--- a/slugger.go
+++ b/slugger.go
@@ -6,8 +6,9 @@ import (
 )
 
 // SlugifyTitle : Make sure to clean up the branch names
-func SlugifyTitle(ticketTitle string) string {
-	re := regexp.MustCompile("[^a-z0-9]+")
-
-	return strings.Trim(re.ReplaceAllString(strings.ToLower(ticketTitle), "-"), "-")
+func SlugifyTitle(ticketTitle string, replacementCharacter string) string {
+	re := regexp.MustCompile("[^a-z0-9]+");
+	lowerCaseTitle := strings.ToLower(ticketTitle)
+	formattedTitle := re.ReplaceAllString(lowerCaseTitle, replacementCharacter)
+	return strings.Trim(formattedTitle, replacementCharacter)
 }

--- a/slugger_test.go
+++ b/slugger_test.go
@@ -13,15 +13,20 @@ var _ = Suite(&SluggerSuite{})
 
 func (s *SluggerSuite) TestSlugCreationNormalText(c *C) {
 	title := "This is a fake title"
-	c.Assert(SlugifyTitle(title), Equals, "this-is-a-fake-title")
+	c.Assert(SlugifyTitle(title, "-"), Equals, "this-is-a-fake-title")
 }
 
 func (s *SluggerSuite) TestSlugCreationWithSpecialChars(c *C) {
 	secondTitle := "This &&& *** is another title"
-	c.Assert(SlugifyTitle(secondTitle), Equals, "this-is-another-title")
+	c.Assert(SlugifyTitle(secondTitle, "_"), Equals, "this_is_another_title")
 }
 
 func (s *SluggerSuite) TestSlugCreationWithMultipleSpaces(c *C) {
 	title := "This is a                    fake title"
-	c.Assert(SlugifyTitle(title), Equals, "this-is-a-fake-title")
+	c.Assert(SlugifyTitle(title, "+"), Equals, "this+is+a+fake+title")
+}
+
+func (s *SluggerSuite) TestSlugCreationWithSpecialCharAtTheEnd(c *C) {
+	title := "This is a fake (title)"
+	c.Assert(SlugifyTitle(title, "+"), Equals, "this+is+a+fake+title")
 }


### PR DESCRIPTION
### Description
One of the main issue that blocked me from using this daily at work was that we are using a different branch naming pattern than the hardcoded one in `gong`.  
Namely something of this format: `XXX-ID/TITLE` with illegal characters being replaced by a `_` rather than the hardcoded `-`.  
Did my best to introduce this, please do comment on the style if something doesn't look right, also I have no experience whatsoever with Go so I might be doing things the wrong way 😅

### Implementation Considerations
- Introduce two new config parameters: `branch_replacement_character ` and `branch_pattern `, see the also modified `Readme.md` for more infos
- Extracted configuration logic into its own `configuration.go` file, no code changed there
- Introduce a `branch.go` file to handle the branch name generation according to the config parameters
- Some more bits and pieces, see comments in the PR

### Testing
- Added a test to the `slugiffy.go` class to handle a edge case I found
- Added tests to the `branch.go` class

