### PR TITLE
Fix syntax error

### DIFF
--- a/cmd/gong/main.go
+++ b/cmd/gong/main.go
@@ -51,7 +51,7 @@ func main() {
 					Value:       "feature",
 					Usage:       "Type of branch to create eg: feature/{ticket-id}-ticket-title",
 					Destination: &branchType,
-					EnvVar: "GONG_DEFAULT_BRANCH_TYPE"
+					EnvVar: "GONG_DEFAULT_BRANCH_TYPE",
 				},
 			},
 			Action: func(c *cli.Context) error {


### PR DESCRIPTION
How do you build if there is no go.mod in the repo?
I can create one by running this is the root of the repo:
```
go mod init github.com/KensoDev/gong
go mod tidy
```

Then I run:
```
./cmd/gong/build.sh minor
```

I get errors:

```
../../../../go/pkg/mod/github.com/segmentio/go-prompt@v1.2.0/prompt.go:76:30: multiple-value gopass.GetPasswd() in single-value context
../../../../go/pkg/mod/github.com/segmentio/go-prompt@v1.2.0/prompt.go:83:36: multiple-value gopass.GetPasswdMasked() in single-value context
```

I see that I need the latest commit from `github.com/segmentio/go-prompt`, which is not the latest tag.
How do I go install dependancies without go.mod but rather latest commits?